### PR TITLE
Fix removeEmptyValues array filtering

### DIFF
--- a/libs/shared-utils/src/lib/object-utils.spec.ts
+++ b/libs/shared-utils/src/lib/object-utils.spec.ts
@@ -1,0 +1,9 @@
+import { removeEmptyValues } from './object-utils';
+
+describe('removeEmptyValues', () => {
+  it('preserves zero and empty string while removing null and undefined', () => {
+    const input = { a: 0, b: '', c: null, d: undefined, e: [0, '', null, undefined] };
+    const result = removeEmptyValues(input);
+    expect(result).toEqual({ a: 0, b: '', e: [0, ''] });
+  });
+});

--- a/libs/shared-utils/src/lib/object-utils.ts
+++ b/libs/shared-utils/src/lib/object-utils.ts
@@ -83,7 +83,9 @@ export function setValue(obj: Record<string, unknown>, path: string, value: unkn
  */
 export function removeEmptyValues(obj: unknown): unknown {
   if (Array.isArray(obj)) {
-    return obj.map(removeEmptyValues).filter(Boolean);
+    return obj
+      .map(removeEmptyValues)
+      .filter((item) => item !== undefined && item !== null);
   }
 
   if (isObject(obj)) {


### PR DESCRIPTION
## Summary
- preserve falsy array values when cleaning objects
- add tests for removeEmptyValues

## Testing
- `npx nx test shared-utils`

------
https://chatgpt.com/codex/tasks/task_e_68703c5d64bc8326bbc0ce0bf949fadf