### PR TITLE
Fix admin routes heading

### DIFF
--- a/docs/admin-routes.md
+++ b/docs/admin-routes.md
@@ -21,7 +21,7 @@
 ### Pastor, Treasurer, Church Admin Routes
 - `/finances` - Financial management page
 
-### Church Admin and up Routes
+### Church Admin Routes
 - `/users` - User management page
 
 ### Church Admin Only Routes


### PR DESCRIPTION
## Summary
- rename a heading in admin routes docs to clarify church admin routes

## Testing
- `npx eslint --version`

------
https://chatgpt.com/codex/tasks/task_e_68703f1481288326bfee9e809477a528