### PR TITLE
Fix double space in API health summary

### DIFF
--- a/apps/api/src/app/app.controller.ts
+++ b/apps/api/src/app/app.controller.ts
@@ -9,7 +9,7 @@ export class AppController {
 
   @Get()
   @ApiOperation({ 
-    summary: 'API Health Check  Information',
+    summary: 'API Health Check Information',
     description: 'Returns API status, version, and basic statistics for health monitoring'
   })
   @ApiResponse({ 


### PR DESCRIPTION
## Summary
- remove unintended control character and extra space in `API Health Check Information` summary

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68703f2d1afc832695c9b87883c0e1d9