### PR TITLE
Update API e2e test

### DIFF
--- a/apps/api-e2e/src/api/api.spec.ts
+++ b/apps/api-e2e/src/api/api.spec.ts
@@ -1,10 +1,16 @@
 import axios from 'axios';
 
 describe('GET /api', () => {
-  it('should return a message', async () => {
+  it('should return API info', async () => {
     const res = await axios.get(`/api`);
 
     expect(res.status).toBe(200);
-    expect(res.data).toEqual({ message: 'Hello API' });
+    expect(res.data).toEqual(
+      expect.objectContaining({
+        service: 'Ekklesia API',
+        version: '1.0.0',
+      })
+    );
+    expect(typeof res.data.status).toBe('string');
   });
 });


### PR DESCRIPTION
## Summary
- update API e2e test to validate new health check output

## Testing
- `npx nx e2e api-e2e` *(fails: TS7053 in libs/database/src/lib/database.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68703f257c848326b8adc7a80b5cce51